### PR TITLE
Add PATCH method into HandlerInfo schema

### DIFF
--- a/src/fnhouse/schemas.clj
+++ b/src/fnhouse/schemas.clj
@@ -55,7 +55,7 @@
    populated by passing an extra-info-fn to the functions in fnhouse.handlers."
   {;; HTTP-related info
    :path (s/both String (s/pred #(.startsWith ^String % "/") 'starts-with-slash?))
-   :method (s/enum :get :head :post :put :delete)
+   :method (s/enum :get :head :post :put :delete :patch)
 
    :description String
 


### PR DESCRIPTION
[RFC5789](http://tools.ietf.org/html/rfc5789) defines PATCH method for partial resource modification. This PR adds PATCH into the list of allowed handler methods.
