### PR TITLE
Allow params to have a schema applied.

### DIFF
--- a/src/fnhouse/handlers.clj
+++ b/src/fnhouse/handlers.clj
@@ -142,7 +142,7 @@
   (letk [[method path] (path-and-method var)
          [{doc ""} {responses {}}] (meta var)
          [{resources {}} {request {}}] (pfnk/input-schema @var)
-         [{uri-args s/Any} {query-params s/Any} {body nil}] request]
+         [{uri-args s/Any} {query-params s/Any} {body nil} {params nil}] request]
     (let [source-map (source-map var)
           explicit-uri-args (dissoc (default-map-schema uri-args) s/Keyword)
           raw-declared-args (routes/uri-arg-ks path)
@@ -153,6 +153,7 @@
                 :description doc
                 :request {:query-params (default-map-schema query-params)
                           :body body
+                          :params params
                           :uri-args (merge
                                      (map-from-keys (constantly String) declared-args)
                                      explicit-uri-args)}

--- a/src/fnhouse/middleware.clj
+++ b/src/fnhouse/middleware.clj
@@ -33,6 +33,7 @@
    better API for specifying matchers is TBD."
   {:uri-args [coerce/string-coercion-matcher]
    :query-params [coerce/string-coercion-matcher]
+   :params [coerce/string-coercion-matcher]
    :body [coerce/json-coercion-matcher]
    :response []})
 
@@ -54,7 +55,7 @@
           (if-let [error (utils/error-val res)]
             (throw (ex-info
                     (format "Request: [%s]<BR>==> Error: [%s]<BR>==> Context: [%s]"
-                            (pr-str (select-keys request [:uri :query-string :body]))
+                            (pr-str (select-keys request [:uri :query-string :params :body]))
                             (pr-str error)
                             context)
                     {:type :coercion-error
@@ -67,7 +68,7 @@
   "Given a custom input coercer, compile a function for coercing and
    validating requests (uri-args, query-params, and body)."
   [input-coercer handler-info]
-  (let [request-walkers (for-map [k [:uri-args :query-params :body]
+  (let [request-walkers (for-map [k [:uri-args :query-params :params :body]
                                   :let [schema (safe-get-in handler-info [:request k])]
                                   :when schema]
                           k

--- a/src/fnhouse/schemas.clj
+++ b/src/fnhouse/schemas.clj
@@ -61,7 +61,8 @@
 
    :request {:uri-args {s/Keyword Schema}
              :query-params fnk-schema/InputSchema
-             :body (s/maybe Schema)}
+             :body (s/maybe Schema)
+             :params (s/maybe Schema)}
    :responses {(s/named s/Int "status code")
                (s/named Schema "response body schema")}
 


### PR DESCRIPTION
Not totally sure this is the way to go about it, but what do you guys think of adding something like this?

The problem that we're running into is that, unless the body is JSON encoded, it comes through in the `body` param as a `org.eclipse.jetty.server.HttpInput` object, which can't have a schema applied to it, and can't be coerced. The `params` param, on the other hand, is a map, so if a schema and coercision is applied, things work just fine.

For slightly more context, we're hitting this when using https://github.com/flowjs/flow.js for file uploads.
