### PR TITLE
assoc error in request ex-info data

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject prismatic/fnhouse "0.1.2-SNAPSHOT"
+(defproject tiensonqin/fnhouse-hacks "0.1.2-SNAPSHOT"
   :description "Transform lightly-annotated functions into a full-fledged web service"
   :license {:name "Eclipse Public License - v 1.0"
             :url "http://www.eclipse.org/legal/epl-v10.html"

--- a/src/fnhouse/handlers.clj
+++ b/src/fnhouse/handlers.clj
@@ -142,7 +142,7 @@
   (letk [[method path] (path-and-method var)
          [{doc ""} {responses {}}] (meta var)
          [{resources {}} {request {}}] (pfnk/input-schema @var)
-         [{uri-args s/Any} {query-params s/Any} {body nil}] request]
+         [{uri-args s/Any} {query-params s/Any} {body nil} {custom nil}] request]
     (let [source-map (source-map var)
           explicit-uri-args (dissoc (default-map-schema uri-args) s/Keyword)
           raw-declared-args (routes/uri-arg-ks path)
@@ -155,7 +155,8 @@
                           :body body
                           :uri-args (merge
                                      (map-from-keys (constantly String) declared-args)
-                                     explicit-uri-args)}
+                                     explicit-uri-args)
+                          :custom custom}
                 :responses responses
 
                 :resources resources

--- a/src/fnhouse/middleware.clj
+++ b/src/fnhouse/middleware.clj
@@ -34,6 +34,7 @@
   {:uri-args [coerce/string-coercion-matcher]
    :query-params [coerce/string-coercion-matcher]
    :body [coerce/json-coercion-matcher]
+   :custom [coerce/string-coercion-matcher]
    :response []})
 
 (s/defn coercing-walker
@@ -54,7 +55,7 @@
           (if-let [error (utils/error-val res)]
             (throw (ex-info
                     (format "Request: [%s]<BR>==> Error: [%s]<BR>==> Context: [%s]"
-                            (pr-str (select-keys request [:uri :query-string :body]))
+                            (pr-str (select-keys request [:uri :query-string :body :custom]))
                             (pr-str error)
                             context)
                     {:type :coercion-error
@@ -68,7 +69,7 @@
   "Given a custom input coercer, compile a function for coercing and
    validating requests (uri-args, query-params, and body)."
   [input-coercer handler-info]
-  (let [request-walkers (for-map [k [:uri-args :query-params :body]
+  (let [request-walkers (for-map [k [:uri-args :query-params :body :custom]
                                   :let [schema (safe-get-in handler-info [:request k])]
                                   :when schema]
                           k

--- a/src/fnhouse/middleware.clj
+++ b/src/fnhouse/middleware.clj
@@ -60,7 +60,8 @@
                     {:type :coercion-error
                      :schema schema
                      :data data
-                     :context context}))
+                     :context context
+                     :error error}))
             res))))))
 
 (defn request-walker

--- a/src/fnhouse/schemas.clj
+++ b/src/fnhouse/schemas.clj
@@ -61,7 +61,8 @@
 
    :request {:uri-args {s/Keyword Schema}
              :query-params fnk-schema/InputSchema
-             :body (s/maybe Schema)}
+             :body (s/maybe Schema)
+             :custom (s/maybe Schema)}
    :responses {(s/named s/Int "status code")
                (s/named Schema "response body schema")}
 


### PR DESCRIPTION
I need parse the error to show readable errors to end user,
for example:

``` clj
;; validation doc
{:password "Use at least 6 characters. Don’t use a password from another site, or something too obvious like your birthdate."
 :email "Email is not legal."}

;; wrap-validation middleware
(defn wrap-validation [f]
  (fn [request]
    (try (f request)
         (catch clojure.lang.ExceptionInfo e
           (let [d (ex-data e)]
             (if (= :coercion-error (:type d))
               {:status 400
                :body {:error (select-keys (:validation doc) (keys (:error d)))}}
               (throw e)))))))
```
